### PR TITLE
pr test

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,52 @@
+services:
+  drupal:
+    build:
+      context: ./drupal
+      dockerfile: Dockerfile
+    ports:
+      - "8081:80"
+    volumes:
+      - ./drupal/app:/opt/drupal
+    depends_on:
+      - drupal-db
+      - python-api
+    environment:
+      - DRUPAL_DATABASE_HOST=drupal-db
+      - DRUPAL_DATABASE_NAME=drupal
+      - DRUPAL_DATABASE_USERNAME=drupal
+      - DRUPAL_DATABASE_PASSWORD=drupal
+    networks:
+      - drupal-network
+
+  python-api:
+    build:
+      context: ./python
+      dockerfile: Dockerfile
+    ports:
+      - "8000:8000"
+    volumes:
+      - ./python:/app
+    environment:
+      - PINECONE_API_KEY=${PINECONE_API_KEY}
+      - PINECONE_INDEX_NAME=${PINECONE_INDEX_NAME}
+    networks:
+      - drupal-network
+
+  drupal-db:
+    image: mariadb:10.11
+    environment:
+      MYSQL_ROOT_PASSWORD: root
+      MYSQL_DATABASE: drupal
+      MYSQL_USER: drupal
+      MYSQL_PASSWORD: drupal
+    volumes:
+      - drupal-db-data:/var/lib/mysql
+    networks:
+      - drupal-network
+
+volumes:
+  drupal-db-data:
+
+networks:
+  drupal-network:
+    driver: bridge


### PR DESCRIPTION
This pull request introduces a new `docker-compose.yml` file to set up a multi-service Docker environment for a Drupal application, a Python API, and a MariaDB database. The configuration includes service definitions, environment variables, volume mappings, and network settings.

Docker environment setup:

* Added a `drupal` service with a custom Dockerfile, port mapping (`8081:80`), volume mapping (`./drupal/app:/opt/drupal`), dependencies (`drupal-db`, `python-api`), environment variables for database configuration, and connection to a custom network (`drupal-network`).
* Added a `python-api` service with a custom Dockerfile, port mapping (`8000:8000`), volume mapping (`./python:/app`), environment variables for Pinecone API integration, and connection to the `drupal-network`.
* Added a `drupal-db` service using the `mariadb:10.11` image, environment variables for database credentials and initialization, volume mapping (`drupal-db-data:/var/lib/mysql`), and connection to the `drupal-network`.
* Defined a persistent volume (`drupal-db-data`) for database storage.
* Created a custom bridge network (`drupal-network`) to allow communication between services.